### PR TITLE
Add VPC endpoint for CloudWatch Logs, add S3 VPC endpoint prefix list to ServicesServerSecurityGroup

### DIFF
--- a/InfraSecBuilderSessionEnvBuild.json
+++ b/InfraSecBuilderSessionEnvBuild.json
@@ -32,7 +32,26 @@
 		"ServicesVPC" : { "ServicesVPCCidr" : "10.1.0.0/16", "ServicesSubnetAZ1" : "10.1.0.0/24", "ServicesSubnetAZ2" : "10.1.128.0/24"},
 		"PoCVPC" : { "PoCVPCCidr" : "10.250.0.0/16", "PoCPublicSubnetAZ1" : "10.250.0.0/24", "PoCPrivateSubnetAZ1" : "10.250.1.0/24", "PoCPublicSubnetAZ2" : "10.250.128.0/24", "PoCPrivateSubnetAZ2" : "10.250.129.0/24"},
 		"OnPrem" : {"OnPremCidr" : "192.168.0.0/16"}
-	}
+	},
+  "VPCEndpointPrefixLists": {
+    "us-east-1" : { "S3" : "pl-63a5400a" },
+    "us-east-2" : { "S3" : "pl-4ca54025" },
+    "us-west-1" : { "S3" : "pl-6ba54002" },
+    "us-west-2" : { "S3" : "pl-68a54001" },
+    "ap-south-1" : { "S3" : "pl-78a54011" },
+    "ap-northeast-1" : { "S3" : "pl-78a54011" },
+    "ap-northeast-2" : { "S3" : "pl-48a54021" },
+    "ap-northeast-3" : { "S3" : "pl-a4a540cd" },
+    "ap-southeast-1" : { "S3" : "pl-6fa54006" },
+    "ap-southeast-2" : { "S3" : "pl-6ca54005" },
+    "ca-central-1" : { "S3" : "pl-4ea54027" },
+    "eu-central-1" : { "S3" : "pl-6ea54007" },
+    "eu-west-1" : { "S3" : "pl-6fa54006" },
+    "eu-west-2" : { "S3" : "pl-b3a742da" },
+    "eu-west-3" : { "S3" : "pl-abb451c2" },
+    "eu-north-1" : { "S3" : "pl-adae4bc4" },
+    "sa-east-1" : { "S3" : "pl-60a54009" }
+  }
   },
   "Resources" : {
 	"WebAppVPC" : {
@@ -591,6 +610,16 @@
 				"FromPort" : 3389,
 				"ToPort" : 3389,
 				"CidrIp" : { "Fn::FindInMap" : [ "IpAddressesForEnv", "WebAppVPC", "WebAppVPCCidr"]}
+			},{
+				"IpProtocol" : "tcp",
+				"FromPort" : 80,
+				"ToPort" : 80,
+				"DestinationPrefixListId" : { "Fn::FindInMap" : [ "VPCEndpointPrefixLists", { "Ref" : "AWS::Region" }, "S3" ]}
+			},{
+				"IpProtocol" : "tcp",
+				"FromPort" : 443,
+				"ToPort" : 443,
+				"DestinationPrefixListId" : { "Fn::FindInMap" : [ "VPCEndpointPrefixLists", { "Ref" : "AWS::Region" }, "S3" ]}
 			}]
 		},
 		"DependsOn" : "ServicesVPC"
@@ -701,6 +730,21 @@
 			"VpcId" : { "Ref" : "ServicesVPC" },
 			"SecurityGroupIds" : [ { "Ref" : "ServicesEndpointSecurityGroup" } ],
 			"ServiceName" : { "Fn::Sub": "com.amazonaws.${AWS::Region}.ec2messages" },
+			"SubnetIds" : [
+				{ "Ref" : "ServicesSubnetAZ1" },
+				{ "Ref" : "ServicesSubnetAZ2" }
+			],
+			"PrivateDnsEnabled" : "True",
+			"VpcEndpointType" : "Interface"
+		},
+		"DependsOn" : [ "ServicesVPC" , "ServicesPrivateRouteTable" , "ServicesEndpointSecurityGroup" ]
+	},
+	"ServicesLogsEndpoint" : {
+		"Type" : "AWS::EC2::VPCEndpoint",
+		"Properties" : {
+			"VpcId" : { "Ref" : "ServicesVPC" },
+			"SecurityGroupIds" : [ { "Ref" : "ServicesEndpointSecurityGroup" } ],
+			"ServiceName" : { "Fn::Sub": "com.amazonaws.${AWS::Region}.logs" },
 			"SubnetIds" : [
 				{ "Ref" : "ServicesSubnetAZ1" },
 				{ "Ref" : "ServicesSubnetAZ2" }


### PR DESCRIPTION
This resolves issue #2 by adding an interface VPC endpoint for CloudWatch Logs, and adding additional security group egress rules to ServicesServerSecurityGroup for HTTP/HTTPS for the prefix list associated with S3 gateway VPC endpoint.

Note the current idiomatic way of obtaining prefix list IDs for a given gateway VPC endpoint is using https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/PrefixListResource which implements a custom resource within CloudFormation. I deemed this overly complex for the purpose of this lab and instead used a mapping containing the prefix list IDs per region.